### PR TITLE
feat: Add `omit_heartbeat_log` option as Raft Config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -98,6 +98,10 @@ pub struct Config {
 
     /// Max size for committed entries in a `Ready`.
     pub max_committed_size_per_ready: u64,
+
+    /// Omit logs related to heartbeat or not. If `true`, logs about messages with type
+    /// `MsgHeartbeat` and `MsgHeartbeatResponse` will be omitted regardless of the log level.
+    pub omit_heartbeat_log: bool,
 }
 
 impl Default for Config {
@@ -120,6 +124,7 @@ impl Default for Config {
             priority: 0,
             max_uncommitted_size: NO_LIMIT,
             max_committed_size_per_ready: NO_LIMIT,
+            omit_heartbeat_log: false,
         }
     }
 }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -251,6 +251,7 @@ pub struct RaftCore<T: Storage> {
 
     /// The logger for the raft structure.
     pub(crate) logger: Arc<dyn Logger>,
+    omit_heartbeat_log: bool,
 
     /// The election priority of this node.
     pub priority: i64,
@@ -368,6 +369,7 @@ impl<T: Storage> Raft<T> {
                     last_log_tail_index: 0,
                 },
                 max_committed_size_per_ready: c.max_committed_size_per_ready,
+                omit_heartbeat_log: c.omit_heartbeat_log,
             },
         };
         confchange::restore(&mut r.prs, r.r.raft_log.last_index(), conf_state)?;
@@ -607,15 +609,19 @@ impl<T: Storage> Raft<T> {
 impl<T: Storage> RaftCore<T> {
     // send persists state to stable storage and then sends to its mailbox.
     fn send(&mut self, mut m: Message, msgs: &mut Vec<Message>) {
-        self.logger.debug(
-            format!(
-                "<<< Sending from {from} to {to}, msg: {msg}",
-                from = self.id,
-                to = m.to,
-                msg = format_message(&m)
-            )
-            .as_str(),
-        );
+        let is_heartbeat_message = m.get_msg_type() == MessageType::MsgHeartbeat
+            || m.get_msg_type() == MessageType::MsgHeartbeatResponse;
+        if !is_heartbeat_message || !self.omit_heartbeat_log {
+            self.logger.debug(
+                format!(
+                    "<<< Sending from {from} to {to}, msg: {msg}",
+                    from = self.id,
+                    to = m.to,
+                    msg = format_message(&m)
+                )
+                    .as_str(),
+            );
+        }
         if m.from == INVALID_ID {
             m.from = self.id;
         }


### PR DESCRIPTION
### Related Issue
This PR is related to the issue https://github.com/lablup/raftify/issues/110.

### Changes
- Add new field `omit_heartbeat_log` to turn off logging heartbeat messages.
  - Default value is `false` as now.
- In RaftCore, check the messageType and the field value to decide whether to log the message before sending it.